### PR TITLE
fix: display tutorials with 1 section, hide sections with no times

### DIFF
--- a/src/components/SectionDetails.tsx
+++ b/src/components/SectionDetails.tsx
@@ -49,18 +49,20 @@ export const SectionDetails: React.FC<SectionDetailsProps> = ({
   const processedSections = processSectionDetails(offering.sections);
   const [showAllSections, setShowAllSections] = useState(false);
   const [showLabTut, setShowLabTut] = useState(false);
+
   const notLabOrTut = (sectionCode: string) =>
     sectionCode !== "LAB" && sectionCode !== "TUT" && sectionCode !== "OPL";
   const initialShownSections =
-    type === "SELECTED_COURSES"
+    type === "SELECTED_COURSES" || processedSections.length === 1
       ? processedSections
       : processedSections.filter((section) =>
           section.schedules.every((sched) => notLabOrTut(sched.sectionCode))
         );
 
   const hasLabTut =
-    processedSections.length > 1 &&
+    processedSections.length >= 1 &&
     processedSections.length !== initialShownSections.length;
+
   const shownSections = showLabTut
     ? processedSections
     : showAllSections

--- a/src/components/SectionDetails.tsx
+++ b/src/components/SectionDetails.tsx
@@ -46,7 +46,9 @@ export const SectionDetails: React.FC<SectionDetailsProps> = ({
   type,
   query,
 }) => {
-  const processedSections = processSectionDetails(offering.sections);
+  const processedSections = processSectionDetails(offering.sections).filter(
+    (section) => section.schedules && section.schedules.length > 0
+  );
   const [showAllSections, setShowAllSections] = useState(false);
   const [showLabTut, setShowLabTut] = useState(false);
 


### PR DESCRIPTION
Great project! Just some changes for edge cases in the sections display logic that can cause some misleading behaviours for users. 

**Proposed changes:**
1. Adjust the logic for tutorials to correctly display a tutorial with only 1 section, and automatically make it visible instead of hiding it in toggle, (Note: I think JAPN should be marked as Lectures instead of tutorials)
2. Adjust the logic for sections to not display the toggle button if the class has sections but doesn't have schedules. Example: CHEM 406-408

**Reasoning:**
1. Users may expect to see multiple tutorials after clicking the tutorial toggle, hiding a single tutorial section may be confusing for some people. Make it display by default if it occurs.
2. Some classes have sections but have no schedules times. Showing a toggle for this could potentially be misleading for some users, as it will open up to an empty view. Hide the toggle if it occurs.

**Tutorials now display even with a single section**
<table>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0d20b40c-deba-4884-a9dd-1584f1b95ed8" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/2a5a3d64-c4c1-43d5-9315-8fc087c5dd1f" width="100%"></td>
  </tr>
</table>

**Toggle hidden if no scheduled times are available**
<table>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/821f395b-c643-44af-beb0-0f54314d7283" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/58ce99ce-8573-44f9-8d5d-537985f4d4b4" width="100%"></td>
  </tr>
</table>
