### PR TITLE
feat: add prerequisites visualization to course page

### DIFF
--- a/src/pages/explore/[code].tsx
+++ b/src/pages/explore/[code].tsx
@@ -161,7 +161,6 @@ const CoursePage: React.FC<CoursePageProps> = () => {
             )}
           </div>
         </div>
-        <RedditPosts query={`${course.dept.toLowerCase()} ${course.number}`} />
         <div>
           <h2 style={{ marginBottom: "6px" }}>prerequisites graph</h2>
           <iframe
@@ -172,6 +171,7 @@ const CoursePage: React.FC<CoursePageProps> = () => {
             title="Prerequisites Visualization"
           ></iframe>
         </div>
+        <RedditPosts query={`${course.dept.toLowerCase()} ${course.number}`} />
       </main>
     </div>
   );


### PR DESCRIPTION
<img width="1918" height="958" alt="image" src="https://github.com/user-attachments/assets/7d16e1f5-66ec-4acd-9933-07f9acd4bd5f" />


todo:
- remove light mode
- get a sfucourses subdomain so the fullscreen button will work